### PR TITLE
feat(gps): dont crash in case of malformed msgs

### DIFF
--- a/Transport/GpsReceiver.php
+++ b/Transport/GpsReceiver.php
@@ -49,6 +49,8 @@ final class GpsReceiver implements ReceiverInterface
             foreach ($messages as $message) {
                 yield $this->createEnvelopeFromPubSubMessage($message);
             }
+        } catch (MessageDecodingFailedException $messageDecodingFailedException) {
+            // Do nothing.
         } catch (Throwable $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
         }

--- a/Transport/GpsTransportFactory.php
+++ b/Transport/GpsTransportFactory.php
@@ -28,7 +28,7 @@ final class GpsTransportFactory implements TransportFactoryInterface
     {
         return new GpsTransport(
             new PubSubClient([
-                'projectId' => getenv('GCLOUD_PROJECT')
+                'projectId' => getenv('GCLOUD_PROJECT'),
             ]),
             $this->gpsConfigurationResolver->resolve($dsn, $options),
             $serializer


### PR DESCRIPTION
# **Description**

MessageDecodingFailedException is triggered when the serializer can not turn the message into a domain entity. 
This fix makes the consumer not crashing. Logging that the message is broken should be done on the app using the bundle.